### PR TITLE
Add language aware search interface

### DIFF
--- a/components/search-box.php
+++ b/components/search-box.php
@@ -1,1 +1,241 @@
-<div class="search-box">            <div class="background2">            <div class="team">                <p>Map a research topic <sup style="color:white;">beta</sup></p>                <p>Get an overview - Find papers - Identify relevant concepts</p>                <!--<p>Faster, more efficient literature search</p>-->            </div>                <form id="searchform" action="#" method="POST" class="mittig2" target="_blank">        <div style="text-align: left;">            <p class="library">                <label class="radio-inline"><input type="radio" name="optradio" value="pubmed" <?php if ($default_lib == "pubmed") echo 'checked="checked"'; ?>>                    <span class="bold">PubMed</span> (life sciences) <!--<a href="#" data-toggle="popover" title="PubMed" data-content="Comprises more                                             than 26 million citations for biomedical literature from MEDLINE, life science                                             journals, and online books. Citations may include links to full-text content from                                             PubMed Central and publisher web sites."><i class="fa fa-info-circle source-info" aria-hidden="true"></i></a>--></label>                            <?php if($DOAJ_FALLBACK): ?>                <label class="radio-inline"><input type="radio" name="optradio" value="doaj" <?php if ($default_lib == "doaj") echo 'checked="checked"'; ?>>                <span class="bold">DOAJ</span> (all disciplines, only open access)</label>            <?php endif; ?>                                <label class="radio-inline"><input type="radio" name="optradio" value="base"                     <?php if ($default_lib == "base") echo 'checked="checked"'; ?> <?php if ($BASE_DOWN == true) echo 'disabled'; ?>                >                    <span class="bold <?php if ($BASE_DOWN == true) echo 'greyed_out'; ?>">BASE</span> <span class="<?php if ($BASE_DOWN == true) echo 'greyed_out'; ?>">(all disciplines)</span>                    <?php if ($BASE_DOWN == true) echo ' <span class="error-message"> Undergoing downtime - please try again later!</span>'; ?>                        <!--<a href="#" data-toggle="popover" title="Bielefeld Academic Search Engine                                               (BASE)" data-content="Provides access to over 100 million documents from                                               more than 5,200 content sources in all disciplines."><i class="fa fa-info-circle source-info" aria-hidden="true"></i></a>--></label>            </p>                        <!--<p class="library">                <span class="library-choice">Refine your search:</span></p>-->            <div id="filter-container"></div>                        <!--<label for="q">Search term:</label> -->            <!--<div class="bg-div">-->            <input type="text" name="q" size="89" required class="text-field"                    id="searchterm" placeholder="Enter your search term">            <button type="submit" class="submit-btn">GO</button>            <!--</div>-->            <!--<div class="filter-btn" style="display: inline-block"><a href="#" id="submit-btn" class="frontend-btn">Submit</a></div>-->        </div>            <p class="try-out-maps">Try out:                 <span class="map-examples base">                    <a class="underline" target="_blank" href="./map/df6a58e07f66344e42a5a5d1aa54bb66">sugar</a>                     <a class="underline" target="_blank" href="./map/685deae1c00a6c5ca9fe91fdef67229c">digital education </a>                </span>                <span class="map-examples pubmed" style="display:none">                    <a class="underline" target="_blank" href="./map/feb3c2d3c7e9a61a5ccbe9ddf9e96ced">heart disease</a>                     <a class="underline" target="_blank" href="./map/381c96aded59683bb14cbe047cb6f701">dental hygiene </a>                </span>            </p>    </form>        </div>    <p style="text-align:center; margin-top: 30px;"><a class="newsletter2" href="about">What is Open Knowledge Maps?</a><p>        </div>            <script type="text/javascript">            var search_options;            var chooseOptions = function () {                search_options = SearchOptions;                switch (config.service) {                    case "plos":                        config.options = options_plos;                        break;                    case "pubmed":                        config.options = options_pubmed;                        break;                    case "doaj":                        config.options = options_doaj;                        break;                    case "base":                        config.options = options_base;                        break;                    default:                        config.options = options_doaj;                }                search_options.init("#filter-container", config.options);                config.options.dropdowns.forEach(function (entry) {                    if (typeof entry.width === "undefined") {                        entry.width = "110px";                    }                    search_options.select_multi('.dropdown_multi_' + entry.id, entry.name, entry.width, config.options)                })                var valueExists = function (key, value) {                    var find = config.options.dropdowns.filter(                            function (data) {                                return data[key] == value                            }                    );                    return (find.length > 0) ? (true) : (false);                }                if (valueExists("id", "time_range")) {                    if (config.service === "pubmed") {                        search_options.addDatePickerFromTo("#from", "#to", "any-time", "1809-01-01");                    } else if (config.service === "base") {                        search_options.addDatePickerFromTo("#from", "#to", "any-time", "1665-01-01");                    } else {                        search_options.addDatePickerFromTo("#from", "#to", "any-time", "1809-01-01");                    }                } else if (valueExists("id", "year_range")) {                    search_options.setDateRangeFromPreset("#from", "#to", "any-time-years", "1809");                }            }            var config = {};            $(document).ready(function () {                $('[data-toggle="popover"]').popover({trigger: "hover", placement: "top"});                                 var changeLibrary = function () {                    config.service = $("input[name='optradio']:checked").val();                    //var radio_val = $(this).val();                    //config.service = radio_val;                    $("#searchform").attr("action", "search?service=" + config.service);                    search_options.user_defined_date = false;                    $("#filter-container").html("");                                        $(".map-examples").css("display", "none");                    $(".map-examples." + config.service).css("display", "inline-block");                    chooseOptions();                };                                 $("input[name='optradio']").change(changeLibrary);                chooseOptions();                $("#searchform").attr("action", "search?service=" + config.service);                                changeLibrary();                                $("#searchterm").focus();            })                        $("#searchform").submit(function () {                var ua = window.navigator.userAgent;                var iOS = !!ua.match(/iPad/i) || !!ua.match(/iPhone/i);                var webkit = !!ua.match(/WebKit/i);                var iOSSafari = iOS && webkit && !ua.match(/CriOS/i);                                if(iOSSafari) {                    $("#searchform").attr("target", "");                }                            })                    </script>
+<div class="search-box">
+    
+        <div class="background2">
+            <div class="team">
+                <p>Map a research topic <sup style="color:white;">beta</sup></p>
+                <p>Get an overview - Find papers - Identify relevant concepts</p>
+                <!--<p>Faster, more efficient literature search</p>-->
+            </div>
+        
+
+    
+
+    <form id="searchform" action="#" method="POST" class="mittig2" target="_blank">
+        <div style="text-align: left;">
+            <p class="library">
+                <label class="radio-inline"><input type="radio" name="optradio" value="pubmed" <?php if ($default_lib == "pubmed") echo 'checked="checked"'; ?>>
+                    <span class="bold">PubMed</span> (life sciences) <!--<a href="#" data-toggle="popover" title="PubMed" data-content="Comprises more 
+                                            than 26 million citations for biomedical literature from MEDLINE, life science 
+                                            journals, and online books. Citations may include links to full-text content from 
+                                            PubMed Central and publisher web sites."><i class="fa fa-info-circle source-info" aria-hidden="true"></i></a>--></label>
+                
+            <?php if($DOAJ_FALLBACK): ?>
+                <label class="radio-inline"><input type="radio" name="optradio" value="doaj" <?php if ($default_lib == "doaj") echo 'checked="checked"'; ?>>
+                <span class="bold">DOAJ</span> (all disciplines, only open access)</label>
+            <?php endif; ?>
+                
+                <label class="radio-inline"><input type="radio" name="optradio" value="base" 
+                    <?php if ($default_lib == "base") echo 'checked="checked"'; ?> <?php if ($BASE_DOWN == true) echo 'disabled'; ?>
+                >
+                    <span class="bold <?php if ($BASE_DOWN == true) echo 'greyed_out'; ?>">BASE</span> <span class="<?php if ($BASE_DOWN == true) echo 'greyed_out'; ?>">(all disciplines)</span>
+                    <?php if ($BASE_DOWN == true) echo ' <span class="error-message"> Undergoing downtime - please try again later!</span>'; ?>
+                        <!--<a href="#" data-toggle="popover" title="Bielefeld Academic Search Engine 
+                                              (BASE)" data-content="Provides access to over 100 million documents from 
+                                              more than 5,200 content sources in all disciplines."><i class="fa fa-info-circle source-info" aria-hidden="true"></i></a>--></label>
+            </p>
+            
+            <!--<p class="library">
+                <span class="library-choice">Refine your search:</span></p>-->
+            <div id="filter-container"></div>
+            
+            <!--<label for="q">Search term:</label> -->
+            <!--<div class="bg-div">-->
+            
+                <span id="base-language-selector-container"></span>
+                    <input type="text" name="q" size="89" required class="text-field" 
+                        id="searchterm" placeholder="Enter your search term">
+                    <button type="submit" class="submit-btn">GO</button>
+
+            <!--</div>-->
+            <!--<div class="filter-btn" style="display: inline-block"><a href="#" id="submit-btn" class="frontend-btn">Submit</a></div>-->
+        </div>
+            <p class="try-out-maps">Try out: 
+                <span class="map-examples base">
+                    <a class="underline" target="_blank" href="./map/df6a58e07f66344e42a5a5d1aa54bb66">sugar</a> 
+                    <a class="underline" target="_blank" href="./map/685deae1c00a6c5ca9fe91fdef67229c">digital education </a>
+                </span>
+                <span class="map-examples pubmed" style="display:none">
+                    <a class="underline" target="_blank" href="./map/feb3c2d3c7e9a61a5ccbe9ddf9e96ced">heart disease</a> 
+                    <a class="underline" target="_blank" href="./map/381c96aded59683bb14cbe047cb6f701">dental hygiene </a>
+                </span>
+            </p>
+    </form>
+
+        </div>
+    <p style="text-align:center; margin-top: 30px;"><a class="newsletter2" href="about">What is Open Knowledge Maps?</a><p>
+        </div>
+
+            <script type="text/javascript">
+
+            var search_options;
+
+            var chooseOptions = function () {
+                search_options = SearchOptions;
+
+                switch (config.service) {
+                    case "plos":
+                        config.options = options_plos;
+                        break;
+
+                    case "pubmed":
+                        config.options = options_pubmed;
+                        break;
+
+                    case "doaj":
+                        config.options = options_doaj;
+                        break;
+
+                    case "base":
+                        config.options = options_base;
+                        break;
+
+                    default:
+                        config.options = options_doaj;
+                }
+
+                search_options.init("#filter-container", config.options);
+
+                config.options.dropdowns.forEach(function (entry) {
+                    if (typeof entry.width === "undefined") {
+                        entry.width = "110px";
+                    }
+                    search_options.select_multi('.dropdown_multi_' + entry.id, entry.name, entry.width, config.options)
+                })
+
+                var valueExists = function (key, value) {
+                    var find = config.options.dropdowns.filter(
+                            function (data) {
+                                return data[key] == value
+                            }
+                    );
+
+                    return (find.length > 0) ? (true) : (false);
+                }
+                if (valueExists("id", "time_range")) {
+                    if (config.service === "pubmed") {
+                        search_options.addDatePickerFromTo("#from", "#to", "any-time", "1809-01-01");
+                    } else if (config.service === "base") {
+                        search_options.addDatePickerFromTo("#from", "#to", "any-time", "1665-01-01");
+                    } else {
+                        search_options.addDatePickerFromTo("#from", "#to", "any-time", "1809-01-01");
+                    }
+                } else if (valueExists("id", "year_range")) {
+                    search_options.setDateRangeFromPreset("#from", "#to", "any-time-years", "1809");
+                }
+
+                // if languages are set in options do the populate here
+                if (config.options.languages !== undefined) {
+                    populateLanguageSelector();
+                } else {
+                    clearLanguageSelector();
+                }
+            }
+
+            var bringLanguageCodeToTop = function (code) {
+                var languageIdx = config.options.languages.findIndex(function (language) { 
+                    return language.code == code;
+                })
+
+                if (languageIdx !== -1) {
+                    var language = config.options.languages[languageIdx]
+                    config.options.languages.splice(languageIdx, 1);
+                    config.options.languages.unshift(language)
+                }
+            }
+
+            var populateLanguageSelector = function () {
+                var select = d3.select("#base-language-selector-container")
+                    .insert('select', "#input-container")
+                    .attr("id", "lang_id")
+                    .style("width", "350px")
+                    .style("overflow", "auto")
+                    .attr("class", "dropdown_multi_language_selector")
+                    .style("vertical-align", "top")
+                    .attr("name","lang_id")
+                
+                // set "all languages" option
+                select.append("option")
+                    .attr("value", "all")
+                    .text("All Languages")
+
+                // find corresponding 3 char language code of browser language
+                var browserLang = search_options.get639_2Frombcp47(window.navigator.language);
+
+                // move browser to top of language list
+                if (browserLang !== null) {
+                    bringLanguageCodeToTop(browserLang);
+                }
+
+                // move english to the very top above browser language
+                bringLanguageCodeToTop("eng");
+
+                config.options.languages.forEach(function (option) {
+                    var current_option = select
+                            .append("option")
+                            .attr("value", option.code)
+                            .text( option.lang_in_eng + " (" + option.lang_in_lang + ")");
+
+                })
+
+                $(function () { $('.dropdown_multi_language_selector').multiselect({
+                    allSelectedText: "All "
+                        , nonSelectedText: "No "
+                        , nSelectedText: "Selected Language"
+                        , buttonWidth: ''
+                        , numberDisplayed: 2
+                        , maxHeight: 230
+                        , enableFiltering: true
+                        , enableCaseInsensitiveFiltering: true
+                } ); } )
+            }
+
+            var clearLanguageSelector = function () {
+                $("#base-language-selector-container").html('')
+            }
+
+            var config = {};
+
+            $(document).ready(function () {
+                $('[data-toggle="popover"]').popover({trigger: "hover", placement: "top"}); 
+                
+                var changeLibrary = function () {
+                    config.service = $("input[name='optradio']:checked").val();
+                    //var radio_val = $(this).val();
+                    //config.service = radio_val;
+                    $("#searchform").attr("action", "search?service=" + config.service);
+
+                    search_options.user_defined_date = false;
+                    $("#filter-container").html("");
+                    
+                    $(".map-examples").css("display", "none");
+                    $(".map-examples." + config.service).css("display", "inline-block");
+
+                    chooseOptions();
+
+
+                }; 
+                
+                $("input[name='optradio']").change(changeLibrary);
+
+                chooseOptions();
+
+                $("#searchform").attr("action", "search?service=" + config.service);
+                
+                changeLibrary();
+                
+                $("#searchterm").focus();
+            })
+            
+            $("#searchform").submit(function () {
+                var ua = window.navigator.userAgent;
+                var iOS = !!ua.match(/iPad/i) || !!ua.match(/iPhone/i);
+                var webkit = !!ua.match(/WebKit/i);
+                var iOSSafari = iOS && webkit && !ua.match(/CriOS/i);
+                
+                if(iOSSafari) {
+                    $("#searchform").attr("target", "");
+                }
+                
+            })
+            
+        </script>

--- a/js/search_options.js
+++ b/js/search_options.js
@@ -259,7 +259,249 @@ var options_base = {
                 , {id: "182", text: "Thesis: master", selected: false}
                 , {id: "52", text: "Video/moving image", selected: false}
             ]}
-    ]
+    ],
+    languages: [
+        {
+          "code": "eng",
+          "lang_in_eng": "English",
+          "lang_in_lang": "English"
+        },
+        {
+          "code": "fre",
+          "lang_in_eng": "French",
+          "lang_in_lang": "français"
+        },
+        {
+          "code": "spa",
+          "lang_in_eng": "Spanish",
+          "lang_in_lang": "español"
+        },
+        {
+          "code": "ger",
+          "lang_in_eng": "German",
+          "lang_in_lang": "Deutsch"
+        },
+        {
+          "code": "por",
+          "lang_in_eng": "Portuguese",
+          "lang_in_lang": "português"
+        },
+        {
+          "code": "pol",
+          "lang_in_eng": "Polish",
+          "lang_in_lang": "Język polski"
+        },
+        {
+          "code": "jpn",
+          "lang_in_eng": "Japanese",
+          "lang_in_lang": "日本語"
+        },
+        {
+          "code": "ita",
+          "lang_in_eng": "Italian",
+          "lang_in_lang": "italiano"
+        },
+        {
+          "code": "chi",
+          "lang_in_eng": "Chinese",
+          "lang_in_lang": "中文"
+        },
+        {
+          "code": "rus",
+          "lang_in_eng": "Russian",
+          "lang_in_lang": "русский язык"
+        },
+        {
+          "code": "ind",
+          "lang_in_eng": "Indonesian",
+          "lang_in_lang": "bahasa Indonesia"
+        },
+        {
+          "code": "ukr",
+          "lang_in_eng": "Ukrainian",
+          "lang_in_lang": "українська мова"
+        },
+        {
+          "code": "gre",
+          "lang_in_eng": "Modern Greek",
+          "lang_in_lang": "Νέα Ελληνικά"
+        },
+        {
+          "code": "cze",
+          "lang_in_eng": "Czech",
+          "lang_in_lang": "čeština"
+        },
+        {
+          "code": "fin",
+          "lang_in_eng": "Finnish",
+          "lang_in_lang": "suomen kieli"
+        },
+        {
+          "code": "swe",
+          "lang_in_eng": "Swedish",
+          "lang_in_lang": "svenska"
+        },
+        {
+          "code": "hun",
+          "lang_in_eng": "Hungarian",
+          "lang_in_lang": "magyar nyelv"
+        },
+        {
+          "code": "tur",
+          "lang_in_eng": "Turkish",
+          "lang_in_lang": "Türkçe"
+        },
+        {
+          "code": "hrv",
+          "lang_in_eng": "Croatian",
+          "lang_in_lang": "hrvatski"
+        },
+        {
+          "code": "geo",
+          "lang_in_eng": "Georgian",
+          "lang_in_lang": "ქართული"
+        },
+        {
+          "code": "grc",
+          "lang_in_eng": "Ancient Greek",
+          "lang_in_lang": "Ἑλληνική"
+        },
+        {
+          "code": "kor",
+          "lang_in_eng": "Korean",
+          "lang_in_lang": "한국어"
+        },
+        {
+          "code": "slv",
+          "lang_in_eng": "Slovenian",
+          "lang_in_lang": "slovenščina"
+        },
+        {
+          "code": "sux",
+          "lang_in_eng": "Sumerian",
+          "lang_in_lang": "𒅴𒂠"
+        },
+        {
+          "code": "nob",
+          "lang_in_eng": "Norwegian Bokmal",
+          "lang_in_lang": "bokmål"
+        },
+        {
+          "code": "rum",
+          "lang_in_eng": "Romanian",
+          "lang_in_lang": "limba română"
+        },
+        {
+          "code": "ara",
+          "lang_in_eng": "Arabic",
+          "lang_in_lang": "العَرَبِيَّة"
+        },
+        {
+          "code": "tha",
+          "lang_in_eng": "Thai",
+          "lang_in_lang": "ภาษาไทย"
+        },
+        {
+          "code": "nor",
+          "lang_in_eng": "Norwegian",
+          "lang_in_lang": "norsk"
+        },
+        {
+          "code": "lat",
+          "lang_in_eng": "Latin",
+          "lang_in_lang": "Lingua latīna"
+        },
+        {
+          "code": "dut",
+          "lang_in_eng": "Dutch",
+          "lang_in_lang": "Nederlands"
+        },
+        {
+          "code": "ice",
+          "lang_in_eng": "Icelandic",
+          "lang_in_lang": "íslenska"
+        },
+        {
+          "code": "lit",
+          "lang_in_eng": "Lithuanian",
+          "lang_in_lang": "lietuvių kalba"
+        },
+        {
+          "code": "srp",
+          "lang_in_eng": "Serbian",
+          "lang_in_lang": "српски"
+        },
+        {
+          "code": "baq",
+          "lang_in_eng": "Basque",
+          "lang_in_lang": "euskara"
+        },
+        {
+          "code": "gle",
+          "lang_in_eng": "Irish",
+          "lang_in_lang": "Gaeilge"
+        },
+        {
+          "code": "afr",
+          "lang_in_eng": "Afrikaans",
+          "lang_in_lang": "Afrikaans"
+        },
+        {
+          "code": "heb",
+          "lang_in_eng": "Hebrew",
+          "lang_in_lang": "עברית"
+        },
+        {
+          "code": "dan",
+          "lang_in_eng": "Danish",
+          "lang_in_lang": "dansk"
+        },
+        {
+          "code": "akk",
+          "lang_in_eng": "Akkadian",
+          "lang_in_lang": "𒀝𒅗𒁺𒌑"
+        },
+        {
+          "code": "slo",
+          "lang_in_eng": "Slovak",
+          "lang_in_lang": "slovenčina"
+        },
+        {
+          "code": "nau",
+          "lang_in_eng": "Nauru",
+          "lang_in_lang": "dorerin Naoero"
+        },
+        {
+          "code": "est",
+          "lang_in_eng": "Estonian",
+          "lang_in_lang": "eesti keel"
+        },
+        {
+          "code": "vie",
+          "lang_in_eng": "Vietnamese",
+          "lang_in_lang": "Tiếng Việt"
+        },
+        {
+          "code": "bel",
+          "lang_in_eng": "Belarusian",
+          "lang_in_lang": "Беларуская мова"
+        },
+        {
+          "code": "glg",
+          "lang_in_eng": "Galician",
+          "lang_in_lang": "galego"
+        },
+        {
+          "code": "ota",
+          "lang_in_eng": "Ottoman Turkish",
+          "lang_in_lang": "لسان عثمانى"
+        },
+        {
+          "code": "per",
+          "lang_in_eng": "Persian",
+          "lang_in_lang": "فارسی"
+        }
+      ]
 }
 
 var options_openaire = {
@@ -429,7 +671,7 @@ var SearchOptions = {
 
         var self = this;
 
-        $(function () {
+         $(function () {
             $(dropdown_class).multiselect({
                 allSelectedText: "All " + entity
                 , nonSelectedText: "No " + entity
@@ -560,5 +802,206 @@ var SearchOptions = {
             self.setDateRangeFromPreset("#from", "#to", init_time_range, start_date);
 
         });
+    },
+    get639_2Frombcp47: function (code) {
+        var lang2to3CodeMapping = {
+            "aa": "aar",
+            "ab": "abk",
+            "af": "afr",
+            "ak": "aka",
+            "sq": "alb",
+            "am": "amh",
+            "ar": "ara",
+            "an": "arg",
+            "hy": "arm",
+            "as": "asm",
+            "av": "ava",
+            "ae": "ave",
+            "ay": "aym",
+            "az": "aze",
+            "ba": "bak",
+            "bm": "bam",
+            "eu": "baq",
+            "be": "bel",
+            "bn": "ben",
+            "bh": "bih",
+            "bi": "bis",
+            "bo": "tib",
+            "bs": "bos",
+            "br": "bre",
+            "bg": "bul",
+            "my": "bur",
+            "ca": "cat",
+            "cs": "cze",
+            "ch": "cha",
+            "ce": "che",
+            "zh": "chi",
+            "cu": "chu",
+            "cv": "chv",
+            "kw": "cor",
+            "co": "cos",
+            "cr": "cre",
+            "cy": "wel",
+            "da": "dan",
+            "de": "ger",
+            "dv": "div",
+            "nl": "dut",
+            "dz": "dzo",
+            "el": "gre",
+            "en": "eng",
+            "eo": "epo",
+            "et": "est",
+            "ee": "ewe",
+            "fo": "fao",
+            "fa": "per",
+            "fj": "fij",
+            "fi": "fin",
+            "fr": "fre",
+            "fy": "fry",
+            "ff": "ful",
+            "ka": "geo",
+            "gd": "gla",
+            "ga": "gle",
+            "gl": "glg",
+            "gv": "glv",
+            "gn": "grn",
+            "gu": "guj",
+            "ht": "hat",
+            "ha": "hau",
+            "he": "heb",
+            "hz": "her",
+            "hi": "hin",
+            "ho": "hmo",
+            "hr": "hrv",
+            "hu": "hun",
+            "ig": "ibo",
+            "is": "ice",
+            "io": "ido",
+            "ii": "iii",
+            "iu": "iku",
+            "ie": "ile",
+            "ia": "ina",
+            "id": "ind",
+            "ik": "ipk",
+            "it": "ita",
+            "jv": "jav",
+            "ja": "jpn",
+            "kl": "kal",
+            "kn": "kan",
+            "ks": "kas",
+            "kr": "kau",
+            "kk": "kaz",
+            "km": "khm",
+            "ki": "kik",
+            "rw": "kin",
+            "ky": "kir",
+            "kv": "kom",
+            "kg": "kon",
+            "ko": "kor",
+            "kj": "kua",
+            "ku": "kur",
+            "lo": "lao",
+            "la": "lat",
+            "lv": "lav",
+            "li": "lim",
+            "ln": "lin",
+            "lt": "lit",
+            "lb": "ltz",
+            "lu": "lub",
+            "lg": "lug",
+            "mk": "mac",
+            "mh": "mah",
+            "ml": "mal",
+            "mi": "mao",
+            "mr": "mar",
+            "ms": "may",
+            "mg": "mlg",
+            "mt": "mlt",
+            "mn": "mon",
+            "na": "nau",
+            "nv": "nav",
+            "nr": "nbl",
+            "nd": "nde",
+            "ng": "ndo",
+            "ne": "nep",
+            "nn": "nno",
+            "nb": "nob",
+            "no": "nor",
+            "ny": "nya",
+            "oc": "oci",
+            "oj": "oji",
+            "or": "ori",
+            "om": "orm",
+            "os": "oss",
+            "pa": "pan",
+            "pi": "pli",
+            "pl": "pol",
+            "pt": "por",
+            "ps": "pus",
+            "qu": "que",
+            "rm": "roh",
+            "ro": "rum",
+            "rn": "run",
+            "ru": "rus",
+            "sg": "sag",
+            "sa": "san",
+            "si": "sin",
+            "sk": "slo",
+            "sl": "slv",
+            "se": "sme",
+            "sm": "smo",
+            "sn": "sna",
+            "sd": "snd",
+            "so": "som",
+            "st": "sot",
+            "es": "spa",
+            "sc": "srd",
+            "sr": "srp",
+            "ss": "ssw",
+            "su": "sun",
+            "sw": "swa",
+            "sv": "swe",
+            "ty": "tah",
+            "ta": "tam",
+            "tt": "tat",
+            "te": "tel",
+            "tg": "tgk",
+            "tl": "tgl",
+            "th": "tha",
+            "ti": "tir",
+            "to": "ton",
+            "tn": "tsn",
+            "ts": "tso",
+            "tk": "tuk",
+            "tr": "tur",
+            "tw": "twi",
+            "ug": "uig",
+            "uk": "ukr",
+            "ur": "urd",
+            "uz": "uzb",
+            "ve": "ven",
+            "vi": "vie",
+            "vo": "vol",
+            "wa": "wln",
+            "wo": "wol",
+            "xh": "xho",
+            "yi": "yid",
+            "yo": "yor",
+            "za": "zha",
+            "zu": "zul"
+          }
+        var parts = code.split('-')
+        if (typeof parts[0] !== 'string') return null // malformed browser language code
+        if ( parts[0].length === 3 ) return parts[0]
+        if ( parts[0].length === 2 ) {
+            if (lang2to3CodeMapping.hasOwnProperty(parts[0])) {
+                return lang2to3CodeMapping[parts[0]]
+            } else {
+                return null // unknown 2 lang code
+            }
+        } else {
+            return null // unknown lang code
+        }
+
     }
 };


### PR DESCRIPTION
Language aware search

- Multiselect + filter built from Jquery
- Languages provided from the list that BASE have
- Languages sorted by frequency of those papers
- Language order: All, English, Browser Lang* -> Normal Sorted order
- Shipped in POST to lang_id

\* This turned out harder than expected due to needing to convert between https://tools.ietf.org/html/bcp47 which is what browsers provide and what we needed.

ISSUES: CSS means the "language selector" is on the wrong line. I spent some time tying to fix but I struggled. Happy to look again but someone else may be quicker.
Formatting, encoding / LineEndings of searchbox.php seemed to differ from rest of repo. I let the editor auto correct but this makes the diff bigger / harder to see the changes.