### PR TITLE
Hotfix for ID creation issue

### DIFF
--- a/js/search_options.js
+++ b/js/search_options.js
@@ -682,9 +682,12 @@ var SearchOptions = {
                 , nonSelectedText: "No " + entity
                 , nSelectedText: entity
                 , buttonWidth: width
-                , numberDisplayed: 2
                 , maxHeight: 250
                 , includeSelectAllOption: true
+                , numberDisplayed: function () {
+                    let is_multiple = $(dropdown_class).prop("multiple");
+                    return is_multiple ? 0 : 1;
+                }()
                 , onChange: function (element, checked) {
                     if (checked === true) {
                         if(dropdown_class === ".dropdown_multi_time_range") {

--- a/search.php
+++ b/search.php
@@ -86,7 +86,10 @@ if(!empty($_POST)) {
                 break;
             
             case "pubmed":
-                $params_array = array("from", "to", "sorting", "article_types");
+                $params_array = array("from", "to", "sorting");
+                if(isset($post_array["article_types"])) {
+                    $params_array[] = "article_types";
+                }
                 break;
             
             case "doaj":

--- a/search.php
+++ b/search.php
@@ -46,16 +46,64 @@ if(isset($_POST["q"])) {
     $_POST = $_SESSION['post'];
 }
 
+function packParamsJSON($params_array, $post_params) {
+
+    if($params_array === null) {
+        return null;
+    }
+
+    $output_array = array();
+
+    foreach ($params_array as $entry) {
+        $current_params = $post_params[$entry];
+        $output_array[$entry] = $current_params;
+    }
+
+    return json_encode($output_array);
+}
+
+function createID($string_array) {
+    $string_to_hash = implode(" ", $string_array);
+    return md5($string_to_hash);
+}
+
 if(!empty($_POST)) {
     $post_array = $_POST;
-    $date = new DateTime();
-    $post_array["today"] = $date->format('Y-m-d');
+    
+    if(!isset($post_array["unique_id"])) {
+        $dirty_query = $post_array["q"];
+        $query = addslashes(trim(strtolower(strip_tags($dirty_query))));
+        
+        $date = new DateTime();
+        $post_array["today"] = $date->format('Y-m-d');
+        
+        $service_get = filter_input(INPUT_GET, "service", FILTER_SANITIZE_STRING);
+        $service = ($service_get !== false && $service_get !== null) ? ($service_get) : ("");
+        $params_array = array();
+        switch ($service) {
+            case "base":
+                $params_array = array("from", "to", "document_types", "sorting");
+                break;
+            
+            case "pubmed":
+                $params_array = array("from", "to", "sorting", "article_types");
+                break;
+            
+            case "doaj":
+                $params_array = array("from", "to", "today", "sorting");
+                break;
+            
+            case "plos":
+                $params_array = array("article_types", "journals", "from", "to", "sorting");
+                break;
+        }
 
-    $dirty_query = $post_array["q"];
-    $post_array["q"] = addslashes(trim(strtolower(strip_tags($dirty_query))));
+        $params_json = packParamsJSON($params_array, $post_array);
+        $unique_id = createID(array($query, $params_json));
 
-    $unique_id = md5(json_encode($post_array));
-    $post_array["unique_id"] = $unique_id;
+        $post_array["q"] = $query;
+        $post_array["unique_id"] = $unique_id;
+    }
 
     $post_data = json_encode($post_array);
 


### PR DESCRIPTION
Hotfixes an ID creation issue on the website that would lead to diverging IDs for older maps.

Tested with BASE maps from the scavenger hunt to ensure that the IDs match. Also verified with PubMed questions with a slightly modified version where in https://github.com/OpenKnowledgeMaps/project-website/blob/hotfix-id-creation/search.php#L89 `article_types` would be removed from the array.

Also tested various fallbacks for unstable Internet and other types of broken connections.

Note that this is only an intermediary solutions as it copies server/service code from Headstart.