### PR TITLE
stubs for PubMed errors

### DIFF
--- a/js/search.js
+++ b/js/search.js
@@ -120,6 +120,12 @@ function executeSearchRequest(service_url, post_data, service, search_term_short
                 if (list_array.length > 0 && list_array[0] === "API error: requested metadata size") {
                     setErrorTexts(error_texts.pubmed_api_fail);
                     return;
+                } else if(list_array.length > 0 && list_array[0] === "API error: PubMed not reachable") {
+                    setErrorTexts(error_texts.pubmed_api_fail);
+                    return;
+                } else if(list_array.length > 0 && list_array[0] === "unexpected PubMed API error") {
+                    setErrorTexts(error_texts.pubmed_api_fail);
+                    return;
                 } else if(list_array.length === 0 || list_array[0] === "unexpected data processing error") {
                     setErrorTexts(error_texts.server_error);
                     return;


### PR DESCRIPTION
This PR makes changes corresponding to https://github.com/OpenKnowledgeMaps/Headstart/pull/510 in which PubMed API-error handling is slightly improved.

For the two additional, distinct errors we can identify, now the generic PubMed fail-text is shown instead of the generic data processing error. It can be adapted later with more specific error messages.