### PR TITLE
Fix invalid meta tags: image url

### DIFF
--- a/news.php
+++ b/news.php
@@ -7,6 +7,7 @@
     
     function getArticleProperties($article) {
         global $SITE_URL;
+        $protocol = !empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off' ? 'https:' : 'http:';
         
         $property_array = array();
         
@@ -24,7 +25,7 @@
             $src = $images->item(0)->getAttribute("src");
             $property_array["image"] = (substr($src, 0, 4) === "http")
                                             ? ($src)
-                                            : ($SITE_URL . $src); 
+                                            : ($protocol . $SITE_URL . $src); 
         } else {
             $property_array["image"] = "";
         }


### PR DESCRIPTION
Fixes an issue where news item images had an invalid image URL in the meta tags